### PR TITLE
Fix improperly formatted http message

### DIFF
--- a/internal/stage_6.go
+++ b/internal/stage_6.go
@@ -9,8 +9,8 @@ import (
 	"net/http/httputil"
 	"time"
 
-	logger "github.com/codecrafters-io/tester-utils/logger"
 	testerutils "github.com/codecrafters-io/tester-utils"
+	logger "github.com/codecrafters-io/tester-utils/logger"
 )
 
 func testHandlesMultipleConcurrentConnections(stageHarness *testerutils.StageHarness) error {
@@ -72,7 +72,7 @@ func createTcpConn(destination string) (net.Conn, error) {
 }
 
 func sendRequestDirectlyOverTcp(logger *logger.Logger, conn net.Conn, i int) error {
-	req := "GET / HTTP/1.1\r\n" + "\r\n"
+	req := "GET / HTTP/1.1\r\n" + "\r\n\r\n"
 	logger.Infof("Sending Request on %d (status line): %s", i, getFirstLine(string(req)))
 	logPrefix := ">>>"
 	logger.Debugf("Sending Request on %d: (Messages with %s prefix are part of this log)", i, logPrefix)


### PR DESCRIPTION
The concurrent connection was sending one less \r\n