### PR TITLE
Bug Fix: Eliminate the possibility of creating only one connection in stage 6.

### DIFF
--- a/internal/stage_6.go
+++ b/internal/stage_6.go
@@ -20,7 +20,7 @@ func testHandlesMultipleConcurrentConnections(stageHarness *testerutils.StageHar
 
 	logger := stageHarness.Logger
 
-	randomInt := rand.Intn(3) + 1
+	randomInt := rand.Intn(2) + 2
 
 	logger.Infof("Creating %d parallel connections", randomInt)
 	conns := make([]net.Conn, randomInt)


### PR DESCRIPTION
## Issue
This stage tests for concurrent connections. 
In the [current implementation](https://github.com/codecrafters-io/http-server-tester/blob/37fcd2729cd385096e29601fb25bfa5a26cb11a4/internal/stage_6.go#L23C2-L23C31) for number of connections made, there is a possibility that the value of  `randomInt` variable can be 1 as the [`rand.Intn`](https://pkg.go.dev/math/rand#Intn) function returns a non-negative pseudo-random number in the half-open interval [0,n).

This may result in a false positive if the feature has not been implemented.
![image](https://github.com/codecrafters-io/http-server-tester/assets/85390033/7491a0d4-f7c5-4f1f-9e63-b754a5a6f378)

## Fix
This PR modifies `randomInt` so that it's values can only be 2 or 3.
