### PR TITLE
Add a curl request string in logs

### DIFF
--- a/internal/curl_string.go
+++ b/internal/curl_string.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+func httpRequestToCurlString(req *http.Request) string {
+	curlCommand := fmt.Sprintf("curl -v -X %s %s%s%s",
+		req.Method, req.URL.String(), formatHeaders(req.Header), formatBody(req))
+
+	return curlCommand
+}
+
+func formatHeaders(headers http.Header) string {
+	var formattedHeaders string
+
+	// The sorting stuff is to make the output reproducible as hash iteration
+	// is not guaranteed generate the same result every time
+	var headerKeys = make([]string, 0, len(headers))
+	for key := range headers {
+		headerKeys = append(headerKeys, key)
+	}
+	sort.Strings(headerKeys)
+
+	for _, key := range headerKeys {
+		values := headers[key]
+		sort.Strings(values)
+
+		for _, value := range values {
+			formattedHeaders += fmt.Sprintf(" -H \"%s: %s\"", key, value)
+		}
+	}
+	return formattedHeaders
+}
+
+func formatBody(req *http.Request) string {
+	if req.Body == nil || bodyToString(req) == "" {
+		return ""
+
+	}
+	return fmt.Sprintf(" -d '%s'", escapeSingleQuotes(bodyToString(req)))
+}
+
+func bodyToString(req *http.Request) string {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return ""
+	}
+
+	req.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	return string(body)
+}
+
+func escapeSingleQuotes(s string) string {
+	return strings.ReplaceAll(s, "'", `\'`)
+}

--- a/internal/curl_string_test.go
+++ b/internal/curl_string_test.go
@@ -1,0 +1,80 @@
+package internal
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCurlCommandGeneration(t *testing.T) {
+	testCases := []struct {
+		name       string
+		method     string
+		url        string
+		headers    map[string]string
+		body       string
+		curlOutput string
+	}{
+		{
+			name:       "GET request with headers",
+			method:     "GET",
+			url:        "https://example.com",
+			headers:    map[string]string{"Header1": "Value1", "Header2": "Value2"},
+			body:       "",
+			curlOutput: "curl -v -X GET https://example.com -H \"Header1: Value1\" -H \"Header2: Value2\"",
+		},
+		{
+			name:       "POST request with body and headers",
+			method:     "POST",
+			url:        "https://example.com",
+			headers:    map[string]string{"Content-Type": "application/json", "Authorization": "Bearer Token"},
+			body:       `{"key": "value"}`,
+			curlOutput: "curl -v -X POST https://example.com -H \"Authorization: Bearer Token\" -H \"Content-Type: application/json\" -d '{\"key\": \"value\"}'",
+		},
+		{
+			name:       "Empty body",
+			method:     "PUT",
+			url:        "https://example.com/resource",
+			headers:    map[string]string{"Content-Type": "text/plain"},
+			body:       "",
+			curlOutput: "curl -v -X PUT https://example.com/resource -H \"Content-Type: text/plain\"",
+		},
+		{
+			name:       "No headers",
+			method:     "DELETE",
+			url:        "https://example.com/item",
+			headers:    map[string]string{},
+			body:       "request body",
+			curlOutput: "curl -v -X DELETE https://example.com/item -d 'request body'",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(tc.method, tc.url, strings.NewReader(tc.body))
+			if err != nil {
+				t.Fatalf("Error creating request: %v", err)
+			}
+
+			for key, value := range tc.headers {
+				req.Header.Set(key, value)
+			}
+
+			curlCommand := httpRequestToCurlString(req)
+
+			if curlCommand != tc.curlOutput {
+				t.Errorf("Expected: %s\nActual: %s", tc.curlOutput, curlCommand)
+			}
+		})
+	}
+}
+
+func stringToReadCloser(s string) *StringReadCloser {
+	return &StringReadCloser{strings.NewReader(s)}
+}
+
+type StringReadCloser struct {
+	*strings.Reader
+}
+
+func (src *StringReadCloser) Close() error { return nil }

--- a/internal/stage_7.go
+++ b/internal/stage_7.go
@@ -20,8 +20,9 @@ func testGetFile(stageHarness *testerutils.StageHarness) error {
 	fileName := randomFileName()
 	fileContent := randomFileContent()
 
+	logger.Infof("Testing existing file")
 	logger.Debugf("Creating file %s in %s", fileName, DATA_DIR)
-	logger.Debugf("File Content:\n%q", fileContent)
+	logger.Debugf("File Content: %q", fileContent)
 	err := createFileWith(DATA_DIR+fileName, fileContent)
 	defer os.Remove(DATA_DIR + fileName)
 
@@ -34,6 +35,7 @@ func testGetFile(stageHarness *testerutils.StageHarness) error {
 		return err
 	}
 
+	logger.Infof("Testing non existent file returns 404")
 	nonExistentFileName := randomFileNameWithPrefix("non-existent")
 	err = testNonExistentFileResponseIs404(logger, nonExistentFileName)
 	if err != nil {

--- a/internal/stage_common.go
+++ b/internal/stage_common.go
@@ -68,7 +68,7 @@ func dumpResponse(logger *logger.Logger, resp *http.Response) error {
 
 func logCurl(logger *logger.Logger, req *http.Request) {
 	logger.Infof("You can use the following curl command to test this locally")
-	logger.Infof("> %s", httpRequestToCurlString(req))
+	logger.Infof("$ %s", httpRequestToCurlString(req))
 }
 
 func sendRequest(client *http.Client, req *http.Request, logger *logger.Logger) (*http.Response, error) {

--- a/internal/stage_common.go
+++ b/internal/stage_common.go
@@ -41,6 +41,7 @@ func logFriendlyHTTPMessage(logger *logger.Logger, msg string, logPrefix string)
 }
 
 func dumpRequest(logger *logger.Logger, req *http.Request) error {
+	logCurl(logger, req)
 	reqDump, err := httputil.DumpRequestOut(req, true)
 	if err != nil {
 		return fmt.Errorf("Failed to dump request: '%v'", err)
@@ -58,12 +59,16 @@ func dumpResponse(logger *logger.Logger, resp *http.Response) error {
 	if err != nil {
 		return fmt.Errorf("Failed to dump rsponse: '%v'", err)
 	}
-	logger.Infof("Received response: (status line) %s", getFirstLine(string(respDump)))
 	logPrefix := ">>>"
 	logger.Debugf("Received response: (Messages with %s prefix are part of this log)", logPrefix)
 	logFriendlyHTTPMessage(logger, string(respDump), logPrefix)
 
 	return nil
+}
+
+func logCurl(logger *logger.Logger, req *http.Request) {
+	logger.Infof("You can use the following curl command to test this locally")
+	logger.Infof("> %s", httpRequestToCurlString(req))
 }
 
 func sendRequest(client *http.Client, req *http.Request, logger *logger.Logger) (*http.Response, error) {


### PR DESCRIPTION
Rationale behind using auto conversion and not just adding these by hand -

- So that we don't have to worry about this every time we change something.
- This will work OOTB in case we do course extensions.
- The usual metric I use for code quality is how easy is it to remove this feature -> in this case we just delete the file and it's test file and fix a compiler error and we are done.