### PR TITLE
feat: remove ip from "connected to" log.

### DIFF
--- a/internal/http/test_cases/send_request_test_case.go
+++ b/internal/http/test_cases/send_request_test_case.go
@@ -30,9 +30,7 @@ func (t *SendRequestTestCase) Run(stageHarness *test_case_harness.TestCaseHarnes
 
 	addr := strings.Split(address, ":")
 	host, port := addr[0], addr[1]
-	remoteAddr := strings.Split(conn.Conn.RemoteAddr().String(), ":")
-	ip := remoteAddr[0]
-	logger.Debugln(fmt.Sprintf("Connected to %s (%s) port %s", host, ip, port))
+	logger.Debugf(fmt.Sprintf("Connected to %s port %s", host, port))
 
 	err = conn.SendRequest(t.Request)
 	if err != nil {

--- a/internal/test_helpers/fixtures/base/pass_all
+++ b/internal/test_helpers/fixtures/base/pass_all
@@ -3,7 +3,7 @@ Debug = true
 [33m[stage-8] [0m[94mRunning tests for Stage #8: post-file[0m
 [33m[stage-8] [0m[36mRunning program[0m
 [33m[stage-8] [0m[94m$ ./your_server.sh --directory /tmp/data/codecrafters.io/http-server-tester/[0m
-[33m[stage-8] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-8] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-8] [0m[94m$ curl -v -X POST http://localhost:4221/files/pear_orange_raspberry_mango -H "Content-Length: 52" -d 'pear banana blueberry banana pear orange grape grape'[0m
 [33m[stage-8] [0m[36m> POST /files/pear_orange_raspberry_mango HTTP/1.1[0m
 [33m[stage-8] [0m[36m> Host: localhost:4221[0m
@@ -28,7 +28,7 @@ Debug = true
 [33m[stage-7] [0m[94mTesting existing file[0m
 [33m[stage-7] [0m[36mCreating file apple_apple_banana_mango in /tmp/data/codecrafters.io/http-server-tester/[0m
 [33m[stage-7] [0m[36mFile Content: "grape banana mango apple pear banana pineapple raspberry"[0m
-[33m[stage-7] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-7] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-7] [0m[94m$ curl -v -X GET http://localhost:4221/files/apple_apple_banana_mango[0m
 [33m[stage-7] [0m[36m> GET /files/apple_apple_banana_mango HTTP/1.1[0m
 [33m[stage-7] [0m[36m> Host: localhost:4221[0m
@@ -47,7 +47,7 @@ Debug = true
 [33m[stage-7] [0m[92m✓ Body is correct[0m
 [33m[stage-7] [0m[92mFirst test passed.[0m
 [33m[stage-7] [0m[94mTesting non existent file returns 404[0m
-[33m[stage-7] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-7] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-7] [0m[94m$ curl -v -X GET http://localhost:4221/files/non-existentapple_apple_mango_banana[0m
 [33m[stage-7] [0m[36m> GET /files/non-existentapple_apple_mango_banana HTTP/1.1[0m
 [33m[stage-7] [0m[36m> Host: localhost:4221[0m
@@ -105,7 +105,7 @@ Debug = true
 [33m[stage-5] [0m[94mRunning tests for Stage #5: parse-headers[0m
 [33m[stage-5] [0m[36mRunning program[0m
 [33m[stage-5] [0m[94m$ ./your_server.sh[0m
-[33m[stage-5] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-5] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-5] [0m[94m$ curl -v -X GET http://localhost:4221/user-agent -H "User-Agent: blueberry/mango"[0m
 [33m[stage-5] [0m[36m> GET /user-agent HTTP/1.1[0m
 [33m[stage-5] [0m[36m> Host: localhost:4221[0m
@@ -130,7 +130,7 @@ Debug = true
 [33m[stage-4] [0m[94mRunning tests for Stage #4: respond-with-content[0m
 [33m[stage-4] [0m[36mRunning program[0m
 [33m[stage-4] [0m[94m$ ./your_server.sh[0m
-[33m[stage-4] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-4] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-4] [0m[94m$ curl -v -X GET http://localhost:4221/echo/banana[0m
 [33m[stage-4] [0m[36m> GET /echo/banana HTTP/1.1[0m
 [33m[stage-4] [0m[36m> Host: localhost:4221[0m
@@ -154,7 +154,7 @@ Debug = true
 [33m[stage-3] [0m[94mRunning tests for Stage #3: respond-with-404[0m
 [33m[stage-3] [0m[36mRunning program[0m
 [33m[stage-3] [0m[94m$ ./your_server.sh[0m
-[33m[stage-3] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-3] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-3] [0m[94m$ curl -v -X GET http://localhost:4221/pear[0m
 [33m[stage-3] [0m[36m> GET /pear HTTP/1.1[0m
 [33m[stage-3] [0m[36m> Host: localhost:4221[0m
@@ -171,7 +171,7 @@ Debug = true
 [33m[stage-2] [0m[94mRunning tests for Stage #2: respond-with-200[0m
 [33m[stage-2] [0m[36mRunning program[0m
 [33m[stage-2] [0m[94m$ ./your_server.sh[0m
-[33m[stage-2] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-2] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-2] [0m[94m$ curl -v -X GET http://localhost:4221/[0m
 [33m[stage-2] [0m[36m> GET / HTTP/1.1[0m
 [33m[stage-2] [0m[36m> Host: localhost:4221[0m

--- a/internal/test_helpers/fixtures/compression/pass_all
+++ b/internal/test_helpers/fixtures/compression/pass_all
@@ -3,14 +3,14 @@ Debug = true
 [33m[stage-11] [0m[94mRunning tests for Stage #11: compression-gzip[0m
 [33m[stage-11] [0m[36mRunning program[0m
 [33m[stage-11] [0m[94m$ ./your_server.sh[0m
-[33m[stage-11] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-11] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-11] [0m[94m$ curl -v -X GET http://localhost:4221/echo/pear -H "Accept-Encoding: gzip"[0m
 [33m[stage-11] [0m[36m> GET /echo/pear HTTP/1.1[0m
 [33m[stage-11] [0m[36m> Host: localhost:4221[0m
 [33m[stage-11] [0m[36m> Accept-Encoding: gzip[0m
 [33m[stage-11] [0m[36m> [0m
 [33m[stage-11] [0m[36mSent bytes: "GET /echo/pear HTTP/1.1\r\nHost: localhost:4221\r\nAccept-Encoding: gzip\r\n\r\n"[0m
-[33m[stage-11] [0m[36mReceived bytes: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 24\r\n\r\n\x1f\x8b\b\x00\x02\x13=f\x02\xff+HM,\x02\x00\xbd<\x8a\xc6\x04\x00\x00\x00"[0m
+[33m[stage-11] [0m[36mReceived bytes: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 24\r\n\r\n\x1f\x8b\b\x00S\xbb=f\x02\xff+HM,\x02\x00\xbd<\x8a\xc6\x04\x00\x00\x00"[0m
 [33m[stage-11] [0m[36m< HTTP/1.1 200 OK[0m
 [33m[stage-11] [0m[36m< Content-Encoding: gzip[0m
 [33m[stage-11] [0m[36m< Content-Length: 24[0m
@@ -29,14 +29,14 @@ Debug = true
 [33m[stage-10] [0m[94mRunning tests for Stage #10: compression-multiple-schemes[0m
 [33m[stage-10] [0m[36mRunning program[0m
 [33m[stage-10] [0m[94m$ ./your_server.sh[0m
-[33m[stage-10] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-10] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-10] [0m[94m$ curl -v -X GET http://localhost:4221/echo/orange -H "Accept-Encoding: encoding-1, gzip, encoding-2"[0m
 [33m[stage-10] [0m[36m> GET /echo/orange HTTP/1.1[0m
 [33m[stage-10] [0m[36m> Host: localhost:4221[0m
 [33m[stage-10] [0m[36m> Accept-Encoding: encoding-1, gzip, encoding-2[0m
 [33m[stage-10] [0m[36m> [0m
 [33m[stage-10] [0m[36mSent bytes: "GET /echo/orange HTTP/1.1\r\nHost: localhost:4221\r\nAccept-Encoding: encoding-1, gzip, encoding-2\r\n\r\n"[0m
-[33m[stage-10] [0m[36mReceived bytes: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 26\r\n\r\n\x1f\x8b\b\x00\x02\x13=f\x02\xff\xcb/J\xccKO\x05\x00x\xb1\xc5\x1d\x06\x00\x00\x00"[0m
+[33m[stage-10] [0m[36mReceived bytes: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 26\r\n\r\n\x1f\x8b\b\x00S\xbb=f\x02\xff\xcb/J\xccKO\x05\x00x\xb1\xc5\x1d\x06\x00\x00\x00"[0m
 [33m[stage-10] [0m[36m< HTTP/1.1 200 OK[0m
 [33m[stage-10] [0m[36m< Content-Encoding: gzip[0m
 [33m[stage-10] [0m[36m< Content-Length: 26[0m
@@ -46,7 +46,7 @@ Debug = true
 [33m[stage-10] [0m[92mReceived response with 200 status code[0m
 [33m[stage-10] [0m[92m✓ Content-Encoding header is present[0m
 [33m[stage-10] [0m[92mFirst test passed.[0m
-[33m[stage-10] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-10] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-10] [0m[94m$ curl -v -X GET http://localhost:4221/echo/orange -H "Accept-Encoding: encoding-1, encoding-2"[0m
 [33m[stage-10] [0m[36m> GET /echo/orange HTTP/1.1[0m
 [33m[stage-10] [0m[36m> Host: localhost:4221[0m
@@ -69,14 +69,14 @@ Debug = true
 [33m[stage-9] [0m[94mRunning tests for Stage #9: compression-content-encoding[0m
 [33m[stage-9] [0m[36mRunning program[0m
 [33m[stage-9] [0m[94m$ ./your_server.sh[0m
-[33m[stage-9] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-9] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-9] [0m[94m$ curl -v -X GET http://localhost:4221/echo/raspberry -H "Accept-Encoding: gzip"[0m
 [33m[stage-9] [0m[36m> GET /echo/raspberry HTTP/1.1[0m
 [33m[stage-9] [0m[36m> Host: localhost:4221[0m
 [33m[stage-9] [0m[36m> Accept-Encoding: gzip[0m
 [33m[stage-9] [0m[36m> [0m
 [33m[stage-9] [0m[36mSent bytes: "GET /echo/raspberry HTTP/1.1\r\nHost: localhost:4221\r\nAccept-Encoding: gzip\r\n\r\n"[0m
-[33m[stage-9] [0m[36mReceived bytes: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 29\r\n\r\n\x1f\x8b\b\x00\x02\x13=f\x02\xff+J,.HJ-*\xaa\x04\x00a\xd5\x10~\t\x00\x00\x00"[0m
+[33m[stage-9] [0m[36mReceived bytes: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 29\r\n\r\n\x1f\x8b\b\x00S\xbb=f\x02\xff+J,.HJ-*\xaa\x04\x00a\xd5\x10~\t\x00\x00\x00"[0m
 [33m[stage-9] [0m[36m< HTTP/1.1 200 OK[0m
 [33m[stage-9] [0m[36m< Content-Encoding: gzip[0m
 [33m[stage-9] [0m[36m< Content-Length: 29[0m
@@ -86,7 +86,7 @@ Debug = true
 [33m[stage-9] [0m[92mReceived response with 200 status code[0m
 [33m[stage-9] [0m[92m✓ Content-Encoding header is present[0m
 [33m[stage-9] [0m[92mFirst test passed.[0m
-[33m[stage-9] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-9] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-9] [0m[94m$ curl -v -X GET http://localhost:4221/echo/raspberry -H "Accept-Encoding: invalid-encoding"[0m
 [33m[stage-9] [0m[36m> GET /echo/raspberry HTTP/1.1[0m
 [33m[stage-9] [0m[36m> Host: localhost:4221[0m
@@ -109,7 +109,7 @@ Debug = true
 [33m[stage-8] [0m[94mRunning tests for Stage #8: post-file[0m
 [33m[stage-8] [0m[36mRunning program[0m
 [33m[stage-8] [0m[94m$ ./your_server.sh --directory /tmp/data/codecrafters.io/http-server-tester/[0m
-[33m[stage-8] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-8] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-8] [0m[94m$ curl -v -X POST http://localhost:4221/files/mango_pear_banana_blueberry -H "Content-Length: 49" -d 'banana pear orange grape grape apple apple banana'[0m
 [33m[stage-8] [0m[36m> POST /files/mango_pear_banana_blueberry HTTP/1.1[0m
 [33m[stage-8] [0m[36m> Host: localhost:4221[0m
@@ -134,7 +134,7 @@ Debug = true
 [33m[stage-7] [0m[94mTesting existing file[0m
 [33m[stage-7] [0m[36mCreating file mango_grape_banana_mango in /tmp/data/codecrafters.io/http-server-tester/[0m
 [33m[stage-7] [0m[36mFile Content: "apple pear banana pineapple raspberry apple apple mango"[0m
-[33m[stage-7] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-7] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-7] [0m[94m$ curl -v -X GET http://localhost:4221/files/mango_grape_banana_mango[0m
 [33m[stage-7] [0m[36m> GET /files/mango_grape_banana_mango HTTP/1.1[0m
 [33m[stage-7] [0m[36m> Host: localhost:4221[0m
@@ -153,7 +153,7 @@ Debug = true
 [33m[stage-7] [0m[92m✓ Body is correct[0m
 [33m[stage-7] [0m[92mFirst test passed.[0m
 [33m[stage-7] [0m[94mTesting non existent file returns 404[0m
-[33m[stage-7] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-7] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-7] [0m[94m$ curl -v -X GET http://localhost:4221/files/non-existentbanana_pear_apple_blueberry[0m
 [33m[stage-7] [0m[36m> GET /files/non-existentbanana_pear_apple_blueberry HTTP/1.1[0m
 [33m[stage-7] [0m[36m> Host: localhost:4221[0m
@@ -222,7 +222,7 @@ Debug = true
 [33m[stage-5] [0m[94mRunning tests for Stage #5: parse-headers[0m
 [33m[stage-5] [0m[36mRunning program[0m
 [33m[stage-5] [0m[94m$ ./your_server.sh[0m
-[33m[stage-5] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-5] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-5] [0m[94m$ curl -v -X GET http://localhost:4221/user-agent -H "User-Agent: pear/strawberry"[0m
 [33m[stage-5] [0m[36m> GET /user-agent HTTP/1.1[0m
 [33m[stage-5] [0m[36m> Host: localhost:4221[0m
@@ -247,7 +247,7 @@ Debug = true
 [33m[stage-4] [0m[94mRunning tests for Stage #4: respond-with-content[0m
 [33m[stage-4] [0m[36mRunning program[0m
 [33m[stage-4] [0m[94m$ ./your_server.sh[0m
-[33m[stage-4] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-4] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-4] [0m[94m$ curl -v -X GET http://localhost:4221/echo/pear[0m
 [33m[stage-4] [0m[36m> GET /echo/pear HTTP/1.1[0m
 [33m[stage-4] [0m[36m> Host: localhost:4221[0m
@@ -271,7 +271,7 @@ Debug = true
 [33m[stage-3] [0m[94mRunning tests for Stage #3: respond-with-404[0m
 [33m[stage-3] [0m[36mRunning program[0m
 [33m[stage-3] [0m[94m$ ./your_server.sh[0m
-[33m[stage-3] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-3] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-3] [0m[94m$ curl -v -X GET http://localhost:4221/pineapple[0m
 [33m[stage-3] [0m[36m> GET /pineapple HTTP/1.1[0m
 [33m[stage-3] [0m[36m> Host: localhost:4221[0m
@@ -288,7 +288,7 @@ Debug = true
 [33m[stage-2] [0m[94mRunning tests for Stage #2: respond-with-200[0m
 [33m[stage-2] [0m[36mRunning program[0m
 [33m[stage-2] [0m[94m$ ./your_server.sh[0m
-[33m[stage-2] [0m[36mConnected to localhost (127.0.0.1) port 4221[0m
+[33m[stage-2] [0m[36mConnected to localhost port 4221[0m
 [33m[stage-2] [0m[94m$ curl -v -X GET http://localhost:4221/[0m
 [33m[stage-2] [0m[36m> GET / HTTP/1.1[0m
 [33m[stage-2] [0m[36m> Host: localhost:4221[0m


### PR DESCRIPTION
For ruby repos, this breaks and the log looks like: 

`Connected to localhost ([) port 4221`