### PR TITLE
CC-1340: Fix loop condition, and update dependencies 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codecrafters-io/http-server-tester
 
 go 1.21
 
-require github.com/codecrafters-io/tester-utils v0.2.26
+require github.com/codecrafters-io/tester-utils v0.2.31
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -12,7 +12,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/sys v0.21.0 // indirect
+	golang.org/x/sys v0.22.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/codecrafters-io/tester-utils v0.2.26 h1:cHc4m34PPXND0jKRDRW977iToVPLWX3O2ETaSkwc1l8=
-github.com/codecrafters-io/tester-utils v0.2.26/go.mod h1:VgP0WmmRsA8L1urWGMXPW4Zv5jcwHwR0LdKZ8ZAEFT4=
+github.com/codecrafters-io/tester-utils v0.2.31 h1:n5qoXTn4wHb7HVNot5Io/JCjGhpw6iBB+bNSBgBiriA=
+github.com/codecrafters-io/tester-utils v0.2.31/go.mod h1:VgP0WmmRsA8L1urWGMXPW4Zv5jcwHwR0LdKZ8ZAEFT4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
@@ -17,8 +17,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
-golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/internal/stage_6.go
+++ b/internal/stage_6.go
@@ -5,12 +5,12 @@ import (
 	"net/http"
 
 	"github.com/codecrafters-io/tester-utils/logger"
+	"github.com/codecrafters-io/tester-utils/random"
 
 	http_assertions "github.com/codecrafters-io/http-server-tester/internal/http/assertions"
 	http_connection "github.com/codecrafters-io/http-server-tester/internal/http/connection"
 	http_parser "github.com/codecrafters-io/http-server-tester/internal/http/parser"
 	"github.com/codecrafters-io/http-server-tester/internal/http/test_cases"
-	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -37,7 +37,7 @@ func testHandlesMultipleConcurrentConnections(stageHarness *test_case_harness.Te
 		return err
 	}
 	logger.Debugf("Sending first set of requests")
-	for i := connectionCount; i < 0; i-- {
+	for i := connectionCount - 1; i >= 0; i-- {
 		// Test connections in reverse order so that we don't accidentally test the listen backlog
 		// Ref: https://github.com/codecrafters-io/http-server-tester/pull/60
 		if err := testCase.RunWithConn(connections[i], logger); err != nil {

--- a/internal/test_helpers/fixtures/base/pass_all
+++ b/internal/test_helpers/fixtures/base/pass_all
@@ -69,6 +69,26 @@ Debug = true
 [33m[stage-6] [0m[36mCreating connection 1[0m
 [33m[stage-6] [0m[36mCreating connection 2[0m
 [33m[stage-6] [0m[36mSending first set of requests[0m
+[33m[stage-6] [0m[94mclient-2: $ curl -v http://localhost:4221/[0m
+[33m[stage-6] [0m[36mclient-2: > GET / HTTP/1.1[0m
+[33m[stage-6] [0m[36mclient-2: > Host: localhost:4221[0m
+[33m[stage-6] [0m[36mclient-2: > [0m
+[33m[stage-6] [0m[36mclient-2: Sent bytes: "GET / HTTP/1.1\r\nHost: localhost:4221\r\n\r\n"[0m
+[33m[stage-6] [0m[36mclient-2: Received bytes: "HTTP/1.1 200 OK\r\n\r\n"[0m
+[33m[stage-6] [0m[36mclient-2: < HTTP/1.1 200 OK[0m
+[33m[stage-6] [0m[36mclient-2: < [0m
+[33m[stage-6] [0m[92mReceived response with 200 status code[0m
+[33m[stage-6] [0m[36mClosing connection 2[0m
+[33m[stage-6] [0m[94mclient-1: $ curl -v http://localhost:4221/[0m
+[33m[stage-6] [0m[36mclient-1: > GET / HTTP/1.1[0m
+[33m[stage-6] [0m[36mclient-1: > Host: localhost:4221[0m
+[33m[stage-6] [0m[36mclient-1: > [0m
+[33m[stage-6] [0m[36mclient-1: Sent bytes: "GET / HTTP/1.1\r\nHost: localhost:4221\r\n\r\n"[0m
+[33m[stage-6] [0m[36mclient-1: Received bytes: "HTTP/1.1 200 OK\r\n\r\n"[0m
+[33m[stage-6] [0m[36mclient-1: < HTTP/1.1 200 OK[0m
+[33m[stage-6] [0m[36mclient-1: < [0m
+[33m[stage-6] [0m[92mReceived response with 200 status code[0m
+[33m[stage-6] [0m[36mClosing connection 1[0m
 [33m[stage-6] [0m[94mCreating 2 parallel connections[0m
 [33m[stage-6] [0m[36mCreating connection 1[0m
 [33m[stage-6] [0m[36mCreating connection 2[0m

--- a/internal/test_helpers/fixtures/compression/pass_all
+++ b/internal/test_helpers/fixtures/compression/pass_all
@@ -10,7 +10,7 @@ Debug = true
 [33m[stage-11] [0m[36m> Accept-Encoding: gzip[0m
 [33m[stage-11] [0m[36m> [0m
 [33m[stage-11] [0m[36mSent bytes: "GET /echo/pear HTTP/1.1\r\nHost: localhost:4221\r\nAccept-Encoding: gzip\r\n\r\n"[0m
-[33m[stage-11] [0m[36mReceived bytes: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 24\r\n\r\n\x1f\x8b\b\x00\xaa\xf0\x8ff\x02\xff+HM,\x02\x00\xbd<\x8a\xc6\x04\x00\x00\x00"[0m
+[33m[stage-11] [0m[36mReceived bytes: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 24\r\n\r\n\x1f\x8b\b\x00U\x04\x90f\x02\xff+HM,\x02\x00\xbd<\x8a\xc6\x04\x00\x00\x00"[0m
 [33m[stage-11] [0m[36m< HTTP/1.1 200 OK[0m
 [33m[stage-11] [0m[36m< Content-Encoding: gzip[0m
 [33m[stage-11] [0m[36m< Content-Length: 24[0m
@@ -36,7 +36,7 @@ Debug = true
 [33m[stage-10] [0m[36m> Accept-Encoding: encoding-1, gzip, encoding-2[0m
 [33m[stage-10] [0m[36m> [0m
 [33m[stage-10] [0m[36mSent bytes: "GET /echo/orange HTTP/1.1\r\nHost: localhost:4221\r\nAccept-Encoding: encoding-1, gzip, encoding-2\r\n\r\n"[0m
-[33m[stage-10] [0m[36mReceived bytes: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 26\r\n\r\n\x1f\x8b\b\x00\xaa\xf0\x8ff\x02\xff\xcb/J\xccKO\x05\x00x\xb1\xc5\x1d\x06\x00\x00\x00"[0m
+[33m[stage-10] [0m[36mReceived bytes: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 26\r\n\r\n\x1f\x8b\b\x00U\x04\x90f\x02\xff\xcb/J\xccKO\x05\x00x\xb1\xc5\x1d\x06\x00\x00\x00"[0m
 [33m[stage-10] [0m[36m< HTTP/1.1 200 OK[0m
 [33m[stage-10] [0m[36m< Content-Encoding: gzip[0m
 [33m[stage-10] [0m[36m< Content-Length: 26[0m
@@ -76,7 +76,7 @@ Debug = true
 [33m[stage-9] [0m[36m> Accept-Encoding: gzip[0m
 [33m[stage-9] [0m[36m> [0m
 [33m[stage-9] [0m[36mSent bytes: "GET /echo/raspberry HTTP/1.1\r\nHost: localhost:4221\r\nAccept-Encoding: gzip\r\n\r\n"[0m
-[33m[stage-9] [0m[36mReceived bytes: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 29\r\n\r\n\x1f\x8b\b\x00\xaa\xf0\x8ff\x02\xff+J,.HJ-*\xaa\x04\x00a\xd5\x10~\t\x00\x00\x00"[0m
+[33m[stage-9] [0m[36mReceived bytes: "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 29\r\n\r\n\x1f\x8b\b\x00U\x04\x90f\x02\xff+J,.HJ-*\xaa\x04\x00a\xd5\x10~\t\x00\x00\x00"[0m
 [33m[stage-9] [0m[36m< HTTP/1.1 200 OK[0m
 [33m[stage-9] [0m[36m< Content-Encoding: gzip[0m
 [33m[stage-9] [0m[36m< Content-Length: 29[0m
@@ -175,6 +175,26 @@ Debug = true
 [33m[stage-6] [0m[36mCreating connection 1[0m
 [33m[stage-6] [0m[36mCreating connection 2[0m
 [33m[stage-6] [0m[36mSending first set of requests[0m
+[33m[stage-6] [0m[94mclient-2: $ curl -v http://localhost:4221/[0m
+[33m[stage-6] [0m[36mclient-2: > GET / HTTP/1.1[0m
+[33m[stage-6] [0m[36mclient-2: > Host: localhost:4221[0m
+[33m[stage-6] [0m[36mclient-2: > [0m
+[33m[stage-6] [0m[36mclient-2: Sent bytes: "GET / HTTP/1.1\r\nHost: localhost:4221\r\n\r\n"[0m
+[33m[stage-6] [0m[36mclient-2: Received bytes: "HTTP/1.1 200 OK\r\n\r\n"[0m
+[33m[stage-6] [0m[36mclient-2: < HTTP/1.1 200 OK[0m
+[33m[stage-6] [0m[36mclient-2: < [0m
+[33m[stage-6] [0m[92mReceived response with 200 status code[0m
+[33m[stage-6] [0m[36mClosing connection 2[0m
+[33m[stage-6] [0m[94mclient-1: $ curl -v http://localhost:4221/[0m
+[33m[stage-6] [0m[36mclient-1: > GET / HTTP/1.1[0m
+[33m[stage-6] [0m[36mclient-1: > Host: localhost:4221[0m
+[33m[stage-6] [0m[36mclient-1: > [0m
+[33m[stage-6] [0m[36mclient-1: Sent bytes: "GET / HTTP/1.1\r\nHost: localhost:4221\r\n\r\n"[0m
+[33m[stage-6] [0m[36mclient-1: Received bytes: "HTTP/1.1 200 OK\r\n\r\n"[0m
+[33m[stage-6] [0m[36mclient-1: < HTTP/1.1 200 OK[0m
+[33m[stage-6] [0m[36mclient-1: < [0m
+[33m[stage-6] [0m[92mReceived response with 200 status code[0m
+[33m[stage-6] [0m[36mClosing connection 1[0m
 [33m[stage-6] [0m[94mCreating 2 parallel connections[0m
 [33m[stage-6] [0m[36mCreating connection 1[0m
 [33m[stage-6] [0m[36mCreating connection 2[0m


### PR DESCRIPTION
This pull request includes changes to the HTTP server tester module and its dependencies. The most significant changes are updates to the version of dependencies, changes in the import order, a fix to a loop condition, and updates to the debug logs in the test cases.

Dependency updates:

* `module github.com/codecrafters-io/http-server-tester` in file `go.mod`: Updated `github.com/codecrafters-io/tester-utils` from `v0.2.26` to `v0.2.31`.
* `require (` in file `go.mod`: Updated `golang.org/x/sys` from `v0.21.0` to `v0.22.0`.

Codebase changes:

* `import (` in file `internal/stage_6.go`: Changed the import order of `github.com/codecrafters-io/tester-utils/random`.
* `func testHandlesMultipleConcurrentConnections(stageHarness *test_case_harness.Te` in file `internal/stage_6.go`: Fixed the condition in the loop to iterate from `connectionCount - 1` to `0` instead of from `connectionCount` to `0`.

Test case updates:

* `Debug = true` in files `internal/test_helpers/fixtures/base/pass_all` and `internal/test_helpers/fixtures/compression/pass_all`: Updated the debug logs in the test cases. [[1]](diffhunk://#diff-2a9311dfbb9e05be1749db1494f54c884634f21200a4ecf5b66e8657dda1a3deR72-R91) [[2]](diffhunk://#diff-52b0721a387b26a672229087badb01d602aed759346bd018ef838f6aa8b9290aL13-R13) [[3]](diffhunk://#diff-52b0721a387b26a672229087badb01d602aed759346bd018ef838f6aa8b9290aL39-R39) [[4]](diffhunk://#diff-52b0721a387b26a672229087badb01d602aed759346bd018ef838f6aa8b9290aL79-R79) [[5]](diffhunk://#diff-52b0721a387b26a672229087badb01d602aed759346bd018ef838f6aa8b9290aR178-R197)