### PR TITLE
CC-1358: fix error message format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ update_tester_utils:
 	go get -u github.com/codecrafters-io/tester-utils
 
 test_with_server: build
-	CODECRAFTERS_SUBMISSION_DIR=./internal/test_helpers/scenarios/pass_all \
+	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/scenarios/pass_all \
 	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\": \"at4\", \"tester_log_prefix\": \"stage-1\", \"title\": \"connect-to-port\"}, {\"slug\": \"ia4\", \"tester_log_prefix\": \"stage-2\", \"title\": \"respond-with-200\"}, {\"slug\": \"ih0\", \"tester_log_prefix\": \"stage-3\", \"title\": \"respond-with-404\"}, {\"slug\": \"cn2\", \"tester_log_prefix\": \"stage-4\", \"title\": \"respond-with-content\"}, {\"slug\": \"fs3\", \"tester_log_prefix\": \"stage-5\", \"title\": \"parse-headers\"}, {\"slug\": \"ej5\", \"tester_log_prefix\": \"stage-6\", \"title\": \"concurrent-connections\"}, {\"slug\": \"ap6\", \"tester_log_prefix\": \"stage-7\", \"title\": \"get-file\"}, {\"slug\": \"qv8\", \"tester_log_prefix\": \"stage-8\", \"title\": \"post-file\"}, {\"slug\": \"df4\", \"tester_log_prefix\": \"stage-9\", \"title\": \"compression-content-encoding\"}, {\"slug\": \"ij8\", \"tester_log_prefix\": \"stage-10\", \"title\": \"compression-multiple-schemes\"}, {\"slug\": \"cr8\", \"tester_log_prefix\": \"stage-11\", \"title\": \"compression-gzip\"}]" \
 	dist/main.out

--- a/internal/http/assertions/http_response_assertion.go
+++ b/internal/http/assertions/http_response_assertion.go
@@ -55,7 +55,7 @@ func (a HTTPResponseAssertion) Run(response http_parser.HTTPResponse, logger *lo
 			return fmt.Errorf("Expected body of length %d, got %d", len(a.Body), len(response.Body))
 		}
 		if string(response.Body) != string(a.Body) {
-			return fmt.Errorf("Expected body %s, got %s", a.Body, response.Body)
+			return fmt.Errorf("Expected body %q, got %q", a.Body, response.Body)
 		}
 
 		logger.Successf("✓ Body is correct")

--- a/internal/stage_11.go
+++ b/internal/stage_11.go
@@ -57,7 +57,7 @@ func testRespondWithEncodedData(stageHarness *test_case_harness.TestCaseHarness)
 	logger.Successf("✓ Body is gzip encoded")
 
 	if string(decodedString) != content {
-		return fmt.Errorf("Expected %s, got %s", content, decodedString)
+		return fmt.Errorf("Expected %q, got %q", content, string(decodedString))
 	}
 	logger.Successf("✓ Body is correct")
 


### PR DESCRIPTION
This pull request includes fixes for error message formats in the `testRespondWithEncodedData` function and `http_response_assertion`. It also updates the `makefile` test command to use the updated env vars.