### PR TITLE
Add more friendly err msg to remind users about concurrent connections

### DIFF
--- a/internal/stage_6.go
+++ b/internal/stage_6.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"fmt"
+
 	"github.com/codecrafters-io/tester-utils/random"
 
 	http_assertions "github.com/codecrafters-io/http-server-tester/internal/http/assertions"
@@ -37,6 +39,9 @@ func testHandlesMultipleConcurrentConnections(stageHarness *test_case_harness.Te
 		// Test connections in reverse order so that we don't accidentally test the listen backlog
 		// Ref: https://github.com/codecrafters-io/http-server-tester/pull/60
 		if err := testCase.RunWithConn(connections[i], logger); err != nil {
+			if i == connectionCount-1 {
+				return fmt.Errorf("Please make sure your server can handle multiple concurrent connections.\n\n%v", err.Error())
+			}
 			return err
 		}
 


### PR DESCRIPTION
Context:

<img width="663" alt="image" src="https://github.com/user-attachments/assets/c5a2873b-c4e9-41e2-bf4e-fd2587d2003f" />

---

Error case:

<img width="843" alt="image" src="https://github.com/user-attachments/assets/2cacc6df-1ac8-46f7-a19d-593b2d28f9c8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages when testing multiple concurrent connections, providing clearer guidance if the first connection attempt fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->