### PR TITLE
Upgrade tester-utils to 0.4.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 toolchain go1.24.2
 
-require github.com/codecrafters-io/tester-utils v0.4.5
+require github.com/codecrafters-io/tester-utils v0.4.9
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -14,7 +14,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/sys v0.34.0 // indirect
+	golang.org/x/sys v0.37.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/codecrafters-io/tester-utils v0.4.5 h1:iSyDAICLI7E8FxMwz0eMRvxCd14P7vfr0KtL8Eh5F8w=
-github.com/codecrafters-io/tester-utils v0.4.5/go.mod h1:Fyrv4IebzjWtvKfpYf8ooYDoOtjYe2qx8bV7KAJpX+w=
+github.com/codecrafters-io/tester-utils v0.4.9 h1:4J9ZdYB8A2vktofPK9ZlaaXOXP1dZD9zSv6cwDZ9srU=
+github.com/codecrafters-io/tester-utils v0.4.9/go.mod h1:Fyrv4IebzjWtvKfpYf8ooYDoOtjYe2qx8bV7KAJpX+w=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
@@ -15,8 +15,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
-golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
+golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/internal/test_helpers/fixtures/init/failure
+++ b/internal/test_helpers/fixtures/init/failure
@@ -3,4 +3,4 @@
 [33m[tester::#AT4] [0m[94mConnecting to localhost:4221 using TCP[0m
 [33m[your_program] [0mhey, i exit immediately!
 [33m[tester::#AT4] [0m[91mLooks like your program has terminated. A HTTP server is expected to be a long-running process.[0m
-[33m[tester::#AT4] [0m[91mTest failed (try setting 'debug: true' in your codecrafters.yml to see more details)[0m
+[33m[tester::#AT4] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/init/timeout
+++ b/internal/test_helpers/fixtures/init/timeout
@@ -15,4 +15,4 @@
 [33m[tester::#AT4] [0m[94mFailed to connect to port 4221, retrying in 1s[0m
 [33m[tester::#AT4] [0m[94mFailed to connect to port 4221, retrying in 1s[0m
 [33m[tester::#AT4] [0m[91mtimed out, test exceeded 15 seconds[0m
-[33m[tester::#AT4] [0m[91mTest failed (try setting 'debug: true' in your codecrafters.yml to see more details)[0m
+[33m[tester::#AT4] [0m[91mTest failed[0m


### PR DESCRIPTION
Upgrade tester-utils to 0.4.9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade `github.com/codecrafters-io/tester-utils` to v0.4.9 and update indirect `golang.org/x/sys` to v0.37.0.
> 
> - **Dependencies**:
>   - Upgrade `github.com/codecrafters-io/tester-utils` from `v0.4.5` to `v0.4.9`.
>   - Update indirect `golang.org/x/sys` from `v0.34.0` to `v0.37.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca93ba34737f2aff78d3852768e362767a2d1aad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->