### PR TITLE
Bump tester utils version to 0.4.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,10 @@ go 1.24.0
 
 toolchain go1.24.2
 
-require github.com/codecrafters-io/tester-utils v0.4.9
+require github.com/codecrafters-io/tester-utils v0.4.13
 
 require (
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
@@ -14,7 +15,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/sys v0.37.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
-github.com/codecrafters-io/tester-utils v0.4.9 h1:4J9ZdYB8A2vktofPK9ZlaaXOXP1dZD9zSv6cwDZ9srU=
-github.com/codecrafters-io/tester-utils v0.4.9/go.mod h1:Fyrv4IebzjWtvKfpYf8ooYDoOtjYe2qx8bV7KAJpX+w=
+github.com/codecrafters-io/tester-utils v0.4.13 h1:6mX5QxR/yM17eW+TfI17iwtmOwTKQnjyDpWllzNrI8I=
+github.com/codecrafters-io/tester-utils v0.4.13/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
@@ -15,8 +17,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
-golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/internal/test_helpers/fixtures/init/failure
+++ b/internal/test_helpers/fixtures/init/failure
@@ -1,6 +1,6 @@
 [33m[tester::#AT4] [0m[94mRunning tests for Stage #AT4 (at4)[0m
 [33m[tester::#AT4] [0m[94m$ ./your_server.sh[0m
 [33m[tester::#AT4] [0m[94mConnecting to localhost:4221 using TCP[0m
-[33m[your_program] [0mhey, i exit immediately!
+[33m[your_program] [0m[0mhey, i exit immediately![0m
 [33m[tester::#AT4] [0m[91mLooks like your program has terminated. A HTTP server is expected to be a long-running process.[0m
 [33m[tester::#AT4] [0m[91mTest failed[0m

--- a/internal/test_helpers/fixtures/init/success_cheat
+++ b/internal/test_helpers/fixtures/init/success_cheat
@@ -4,7 +4,7 @@ Debug = true
 [33m[tester::#AT4] [0m[36mRunning program[0m
 [33m[tester::#AT4] [0m[94m$ ./your_server.sh[0m
 [33m[tester::#AT4] [0m[94mConnecting to localhost:4221 using TCP[0m
-[33m[your_program] [0mhey, spawning a server
+[33m[your_program] [0m[0mhey, spawning a server[0m
 [33m[tester::#AT4] [0m[94mSuccess! Closing connection[0m
 [33m[tester::#AT4] [0m[92mTest passed.[0m
 [33m[tester::#AT4] [0m[36mTerminating program[0m

--- a/internal/test_helpers/fixtures/init/timeout
+++ b/internal/test_helpers/fixtures/init/timeout
@@ -1,7 +1,7 @@
 [33m[tester::#AT4] [0m[94mRunning tests for Stage #AT4 (at4)[0m
 [33m[tester::#AT4] [0m[94m$ ./your_server.sh[0m
 [33m[tester::#AT4] [0m[94mConnecting to localhost:4221 using TCP[0m
-[33m[your_program] [0mhey, i don't do anything but I take a while to exit!
+[33m[your_program] [0m[0mhey, i don't do anything but I take a while to exit![0m
 [33m[tester::#AT4] [0m[94mFailed to connect to port 4221, retrying in 1s[0m
 [33m[tester::#AT4] [0m[94mFailed to connect to port 4221, retrying in 1s[0m
 [33m[tester::#AT4] [0m[94mFailed to connect to port 4221, retrying in 1s[0m


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Deps:** Update `github.com/codecrafters-io/tester-utils` to `v0.4.13`; bump `golang.org/x/sys` to `v0.40.0`; add indirect `github.com/creack/pty`.
> - **Fixtures:** Refresh `internal/test_helpers/fixtures/init/*` to match new ANSI color/reset sequences in `[your_program]` lines.
> - *Housekeeping:* Update `go.sum` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f0e8e1c6587faff7f2cb06b772a97350b9645e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->