### PR TITLE
CC-2143: Update tester-utils to v0.4.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 toolchain go1.24.2
 
-require github.com/codecrafters-io/tester-utils v0.4.13
+require github.com/codecrafters-io/tester-utils v0.4.15
 
 require (
 	github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/codecrafters-io/tester-utils v0.4.13 h1:6mX5QxR/yM17eW+TfI17iwtmOwTKQnjyDpWllzNrI8I=
-github.com/codecrafters-io/tester-utils v0.4.13/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.15 h1:5scq/S1Eiz68yF+wcCIr59M5xWb/gLbrqvylwD2oDlc=
+github.com/codecrafters-io/tester-utils v0.4.15/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
CC-2143: Update tester-utils to v0.4.15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no code changes; risk is limited to any behavioral differences introduced by the updated `tester-utils` version.
> 
> **Overview**
> Updates the Go dependency `github.com/codecrafters-io/tester-utils` from `v0.4.13` to `v0.4.15`, refreshing `go.mod` and `go.sum` checksums accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9666d0a1f757ffcee0a7516f0dd9f11d0374e1af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->